### PR TITLE
mysql clientを追加

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,9 @@
 ARG VARIANT="buster"
 FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
 
+RUN apt-get update && \
+    apt-get -y install default-mysql-client
+
 # [Optional] Uncomment this section to install additional packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>


### PR DESCRIPTION
コンテナの中で↓を手打ちしていたものをDockerfileに入れる

> ## install cli
> $ sudo apt update
> $ sudo apt install default-mysql-client